### PR TITLE
Clean up of original rust library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,10 @@
 
 name = "rust_tessel"
 version = "0.0.1"
-authors = ["Kenneth Nierenhausen <kennethnierenhausen@gmail.com>"]
+authors = [
+	"Kenneth Nierenhausen <kennethnierenhausen@gmail.com>",
+	"Chris Lewis <cflewis@google.com>"
+]
 
 [dependencies]
 unix_socket = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,9 @@ authors = [
 	"Chris Lewis <cflewis@google.com>"
 ]
 
+[[bin]]
+name = "main"
+doc = false
+
 [dependencies]
 unix_socket = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ doc = false
 
 [dependencies]
 unix_socket = "0.5.0"
+
+[dev-dependencies]
+tempfile = "2.1.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,16 +8,21 @@ const PORT_B_UDS_PATH: &'static str = "/var/run/tessel/port_b";
 
 /// Primary exported Tessel object with access to module ports, LEDs, and a button.
 /// # Example
+/// ```
 /// use rust_tessel::Tessel;
 ///
+/// # #[allow(dead_code)]
+/// # fn example() {
 /// let t = Tessel::new();
 /// // Tessel 2 has four LEDs available.
-/// assert_eq(t.led.len(), 4);
+/// assert_eq!(t.led.len(), 4);
 /// // Tessel 2 has two ports labelled a and b
-/// assert(t.ports.a);
-/// assert(t.ports.b);
+/// let a = t.port.a;
+/// let b = t.port.b;
 /// // Tessel 2 has one button.
-/// assert(t.button);
+/// let button = t.button;
+/// # }
+/// ```
 pub struct Tessel {
     // A group of module ports.
     pub port: PortGroup,
@@ -54,8 +59,8 @@ impl Tessel {
 /// A PortGroup is a simple way to access each port through its letter identifier.
 #[allow(dead_code)]
 pub struct PortGroup {
-    a: Port,
-    b: Port
+    pub a: Port,
+    pub b: Port
 }
 
 /// A Port is a model of the Tessel hardware ports.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,8 +75,9 @@ pub struct Port {
     pub socket_path: &'static str
 }
 
+// TODO: Figure out how to override the path so secretly so the example
+// can actually be run.
 /// A LED models an LED on the Tessel board.
-/// // TODO: Figure out how to override the path so secretly so this can actually be run.
 /// # Example
 /// ```rust,no_run
 /// use rust_tessel::LED;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,18 @@ use std::io::Write;
 const PORT_A_UDS_PATH: &'static str = "/var/run/tessel/port_a";
 const PORT_B_UDS_PATH: &'static str = "/var/run/tessel/port_b";
 
-// Primary exported Tessel object with access to module ports, LEDs, and a button.
-#[allow(dead_code)]
+/// Primary exported Tessel object with access to module ports, LEDs, and a button.
+/// # Example
+/// use rust_tessel::Tessel;
+///
+/// let t = Tessel::new();
+/// // Tessel 2 has four LEDs available.
+/// assert_eq(t.led.len(), 4);
+/// // Tessel 2 has two ports labelled a and b
+/// assert(t.ports.a);
+/// assert(t.ports.b);
+/// // Tessel 2 has one button.
+/// assert(t.button);
 pub struct Tessel {
     // A group of module ports.
     pub port: PortGroup,
@@ -18,11 +28,10 @@ pub struct Tessel {
 }
 
 impl Tessel {
-    // Returns a new Tessel object.
     pub fn new() -> Tessel {
 
         // Create a port group with two ports, one on each domain socket path.
-        let ports = PortGroup { a: Port::new(PORT_A_UDS_PATH), b: Port::new(PORT_B_UDS_PATH) };
+        let ports = PortGroup { a: Port{socket_path: PORT_A_UDS_PATH}, b: Port{socket_path: PORT_B_UDS_PATH}};
 
         // Create models for the four LEDs.
         let red_led = LED::new("red", "error");
@@ -31,7 +40,7 @@ impl Tessel {
         let blue_led = LED::new("blue", "user2");
 
         // Create the button.
-        let button =  Button::new();
+        let button =  Button{value: false};
 
         // Return the Tessel with these fields.
         Tessel {
@@ -42,34 +51,37 @@ impl Tessel {
     }
 }
 
-// A PortGroup is a simple way to access each port through its letter identifier.
+/// A PortGroup is a simple way to access each port through its letter identifier.
 #[allow(dead_code)]
 pub struct PortGroup {
     a: Port,
     b: Port
 }
 
-// A Port is a model of the Tessel hardware ports.
-#[allow(dead_code)]
+/// A Port is a model of the Tessel hardware ports.
+/// # Example
+/// ```
+/// use rust_tessel::Port;
+///
+/// let p = Port{socket_path: "path/to/my/socket"};
+/// ```
 pub struct Port {
     // Path of the domain socket.
-    socket_path: &'static str
+    pub socket_path: &'static str
 }
 
-impl Port {
-    pub fn new(path: &'static str) -> Port {
-        Port {
-            socket_path: path
-        }
-    }
-}
-
-#[allow(dead_code)]
+/// A LED models an LED on the Tessel board.
+/// // TODO: Figure out how to override the path so secretly so this can actually be run.
+/// # Example
+/// ```rust,no_run
+/// use rust_tessel::LED;
+///
+/// let mut led = LED::new("red", "error");
+/// // LEDs are off by default.
+/// assert_eq!(false, led.read());
+/// led.on().unwrap();
+/// assert_eq!(true, led.read());
 pub struct LED {
-    // The color of the given LED (used in filepath creation).
-    color: &'static str,
-    // The type of LED (used in filepath creation).
-    kind: &'static str,
     // The file object we write to in order to change state.
     file: File,
     // The current value of the LED, defaults to false.
@@ -78,12 +90,9 @@ pub struct LED {
 
 impl LED {
     pub fn new(color: &'static str, kind: &'static str) -> LED {
-
         let path = format!("/sys/devices/leds/leds/tessel:{}:{}/brightness", color, kind);
 
         let mut led = LED {
-            color: color,
-            kind: kind,
             value: false,
             // Open the file for write operations.
             file: File::create(path).unwrap()
@@ -141,17 +150,15 @@ impl LED {
     }
 }
 
-// A model of the single button on Tessel.
-#[allow(dead_code)]
+/// A model of the single button on Tessel.
+/// # Example
+/// ```
+/// use rust_tessel::Button;
+///
+/// let b = Button{value: false};
+/// ```
 pub struct Button {
     // The button's current state.
-    value: bool
+    pub value: bool
 }
 
-impl Button {
-    pub fn new() -> Button {
-        Button {
-            value: false
-        }
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,40 +1,39 @@
-// File operations used for modifying LED state
 use std::fs::File;
 use std::io;
 use std::io::Write;
 
-// Paths to spi daemon sockets with incoming data from coprocessor
+// Paths to the SPI daemon sockets with incoming data from coprocessor.
 const PORT_A_UDS_PATH: &'static str = "/var/run/tessel/port_a";
 const PORT_B_UDS_PATH: &'static str = "/var/run/tessel/port_b";
 
-// Primary exported Tessel object with access to module ports, leds, and a button
+// Primary exported Tessel object with access to module ports, LEDs, and a button.
 #[allow(dead_code)]
 pub struct Tessel {
-    // A group of module ports
+    // A group of module ports.
     pub port: PortGroup,
-    // An array of LED structs
+    // An array of LED structs.
     pub led: Vec<LED>,
-    // A single button struct
+    // A single button struct.
     pub button: Button
 }
 
 impl Tessel {
-    // Factory metho for Tessel
+    // Returns a new Tessel object.
     pub fn new() -> Tessel {
 
-        // Create a port group with two ports, one on each domain socket path
+        // Create a port group with two ports, one on each domain socket path.
         let ports = PortGroup { a: Port::new(PORT_A_UDS_PATH), b: Port::new(PORT_B_UDS_PATH) };
 
-        // Create models for the four LEDs
+        // Create models for the four LEDs.
         let red_led = LED::new("red", "error");
         let amber_led = LED::new("amber", "wlan");
         let green_led = LED::new("green", "user1");
         let blue_led = LED::new("blue", "user2");
 
-        // Create the button
+        // Create the button.
         let button =  Button::new();
 
-        // Return the Tessel with these fields
+        // Return the Tessel with these fields.
         Tessel {
             port: ports,
             led: vec![red_led, amber_led, green_led, blue_led],
@@ -43,22 +42,21 @@ impl Tessel {
     }
 }
 
-// A group is a simple way to access each port through its letter identifier
+// A PortGroup is a simple way to access each port through its letter identifier.
 #[allow(dead_code)]
 pub struct PortGroup {
     a: Port,
     b: Port
 }
 
-// A model of the Tessel hardware ports
+// A Port is a model of the Tessel hardware ports.
 #[allow(dead_code)]
 pub struct Port {
-    // string slice to the path of the domain socket
+    // Path of the domain socket.
     socket_path: &'static str
 }
 
 impl Port {
-    // Factory method for returning a new port struct
     pub fn new(path: &'static str) -> Port {
         Port {
             socket_path: path
@@ -68,95 +66,89 @@ impl Port {
 
 #[allow(dead_code)]
 pub struct LED {
-    // The color of the given LED (used in filepath creation)
+    // The color of the given LED (used in filepath creation).
     color: &'static str,
-    // The type of LED (used in filepath creation)
+    // The type of LED (used in filepath creation).
     kind: &'static str,
-    // The file object we write to in order to change state
+    // The file object we write to in order to change state.
     file: File,
-    // The current value of the LED, defaults to false
+    // The current value of the LED, defaults to false.
     value: bool
 }
 
 impl LED {
-    // Factory method for creating new LEDs
     pub fn new(color: &'static str, kind: &'static str) -> LED {
 
-        // Assemble the file path
         let path = format!("/sys/devices/leds/leds/tessel:{}:{}/brightness", color, kind);
 
-        // Create the LED struct
         let mut led = LED {
             color: color,
             kind: kind,
             value: false,
-            // Opens the file for write operations
+            // Open the file for write operations.
             file: File::create(path).unwrap()
         };
 
-        // Turn the LED off by default
+        // Turn the LED off by default.
         led.off().unwrap();
 
-        // Returns the LED
         led
     }
 
-    // Turns the LED on (same as `high`)
+    // Turn the LED on (same as `high`).
     pub fn on(&mut self)-> Result<(), io::Error> {
-        self.write(true)
+        self.high()
     }
 
-    // Turns the LED off (same as `low`)
+    // Turn the LED off (same as `low`).
     pub fn off(&mut self)-> Result<(), io::Error> {
-        self.write(false)
+        self.low()
     }
 
-    // Turns the LED on
+    // Turn the LED on.
     pub fn high(&mut self)-> Result<(), io::Error> {
         self.write(true)
     }
 
-    // Turns the LED off
+    // Turn the LED off.
     pub fn low(&mut self)-> Result<(), io::Error> {
         self.write(false)
     }
 
-    // Sets the LED to the opposite of its current state
+    // Sets the LED to the opposite of its current state.
     pub fn toggle(&mut self)-> Result<(), io::Error> {
         let new_value = !self.value;
         self.write(new_value)
     }
 
-    // Returns the current state of the LED
+    // Returns the current state of the LED.
     pub fn read(&self)-> bool {
         self.value
     }
 
-    // Helper function to write new state to LED filepath
+    // Helper function to write new state to LED filepath.
     fn write(&mut self, new_value: bool)-> Result<(), io::Error> {
-
-        // Save the new value to the model
+        // Save the new value to the model.
         self.value = new_value;
-        // Return the binary representation of that value type
+        // Return the binary representation of that value type.
         let string_value = match new_value {
             true => b'1',
             false => b'0'
         };
 
-        // Write that data to the file and return the result
+        // Write that data to the file and return the result.
         self.file.write_all(&[string_value])
     }
 }
 
-// A model of the single button on Tessel
+// A model of the single button on Tessel.
 #[allow(dead_code)]
 pub struct Button {
-    // The button's current state
+    // The button's current state.
     value: bool
 }
 
 impl Button {
-    // Factory method for new buttons
     pub fn new() -> Button {
         Button {
             value: false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,14 +29,17 @@ pub struct Tessel {
     // An array of LED structs.
     pub led: Vec<LED>,
     // A single button struct.
-    pub button: Button
+    pub button: Button,
 }
 
 impl Tessel {
     pub fn new() -> Tessel {
 
         // Create a port group with two ports, one on each domain socket path.
-        let ports = PortGroup { a: Port{socket_path: PORT_A_UDS_PATH}, b: Port{socket_path: PORT_B_UDS_PATH}};
+        let ports = PortGroup {
+            a: Port { socket_path: PORT_A_UDS_PATH },
+            b: Port { socket_path: PORT_B_UDS_PATH },
+        };
 
         // Create models for the four LEDs.
         let red_led = LED::new("red", "error");
@@ -45,13 +48,13 @@ impl Tessel {
         let blue_led = LED::new("blue", "user2");
 
         // Create the button.
-        let button =  Button{value: false};
+        let button = Button { value: false };
 
         // Return the Tessel with these fields.
         Tessel {
             port: ports,
             led: vec![red_led, amber_led, green_led, blue_led],
-            button: button
+            button: button,
         }
     }
 }
@@ -60,7 +63,7 @@ impl Tessel {
 #[allow(dead_code)]
 pub struct PortGroup {
     pub a: Port,
-    pub b: Port
+    pub b: Port,
 }
 
 /// A Port is a model of the Tessel hardware ports.
@@ -72,7 +75,7 @@ pub struct PortGroup {
 /// ```
 pub struct Port {
     // Path of the domain socket.
-    pub socket_path: &'static str
+    pub socket_path: &'static str,
 }
 
 // TODO: Figure out how to override the path so secretly so the example
@@ -91,17 +94,19 @@ pub struct LED {
     // The file object we write to in order to change state.
     file: File,
     // The current value of the LED, defaults to false.
-    value: bool
+    value: bool,
 }
 
 impl LED {
     pub fn new(color: &'static str, kind: &'static str) -> LED {
-        let path = format!("/sys/devices/leds/leds/tessel:{}:{}/brightness", color, kind);
+        let path = format!("/sys/devices/leds/leds/tessel:{}:{}/brightness",
+                           color,
+                           kind);
 
         let mut led = LED {
             value: false,
             // Open the file for write operations.
-            file: File::create(path).unwrap()
+            file: File::create(path).unwrap(),
         };
 
         // Turn the LED off by default.
@@ -111,44 +116,44 @@ impl LED {
     }
 
     // Turn the LED on (same as `high`).
-    pub fn on(&mut self)-> Result<(), io::Error> {
+    pub fn on(&mut self) -> Result<(), io::Error> {
         self.high()
     }
 
     // Turn the LED off (same as `low`).
-    pub fn off(&mut self)-> Result<(), io::Error> {
+    pub fn off(&mut self) -> Result<(), io::Error> {
         self.low()
     }
 
     // Turn the LED on.
-    pub fn high(&mut self)-> Result<(), io::Error> {
+    pub fn high(&mut self) -> Result<(), io::Error> {
         self.write(true)
     }
 
     // Turn the LED off.
-    pub fn low(&mut self)-> Result<(), io::Error> {
+    pub fn low(&mut self) -> Result<(), io::Error> {
         self.write(false)
     }
 
     // Sets the LED to the opposite of its current state.
-    pub fn toggle(&mut self)-> Result<(), io::Error> {
+    pub fn toggle(&mut self) -> Result<(), io::Error> {
         let new_value = !self.value;
         self.write(new_value)
     }
 
     // Returns the current state of the LED.
-    pub fn read(&self)-> bool {
+    pub fn read(&self) -> bool {
         self.value
     }
 
     // Helper function to write new state to LED filepath.
-    fn write(&mut self, new_value: bool)-> Result<(), io::Error> {
+    fn write(&mut self, new_value: bool) -> Result<(), io::Error> {
         // Save the new value to the model.
         self.value = new_value;
         // Return the binary representation of that value type.
         let string_value = match new_value {
             true => b'1',
-            false => b'0'
+            false => b'0',
         };
 
         // Write that data to the file and return the result.
@@ -165,6 +170,5 @@ impl LED {
 /// ```
 pub struct Button {
     // The button's current state.
-    pub value: bool
+    pub value: bool,
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,6 @@ const PORT_B_UDS_PATH: &'static str = "/var/run/tessel/port_b";
 /// // Tessel 2 has two ports labelled a and b
 /// let a = t.port.a;
 /// let b = t.port.b;
-/// // Tessel 2 has one button.
-/// let button = t.button;
 /// # }
 /// ```
 pub struct Tessel {
@@ -28,13 +26,11 @@ pub struct Tessel {
     pub port: PortGroup,
     // An array of LED structs.
     pub led: Vec<LED>,
-    // A single button struct.
-    pub button: Button,
 }
 
 impl Tessel {
+    // new() returns a Tessel struct conforming to the Tessel 2's functionality.
     pub fn new() -> Tessel {
-
         // Create a port group with two ports, one on each domain socket path.
         let ports = PortGroup {
             a: Port { socket_path: PORT_A_UDS_PATH },
@@ -47,14 +43,10 @@ impl Tessel {
         let green_led = LED::new("green", "user1");
         let blue_led = LED::new("blue", "user2");
 
-        // Create the button.
-        let button = Button { value: false };
-
         // Return the Tessel with these fields.
         Tessel {
             port: ports,
             led: vec![red_led, amber_led, green_led, blue_led],
-            button: button,
         }
     }
 }
@@ -78,7 +70,7 @@ pub struct Port {
     pub socket_path: &'static str,
 }
 
-// TODO: Figure out how to override the path so secretly so the example
+// TODO: Figure out how to override the path secretly so the example
 // can actually be run.
 /// A LED models an LED on the Tessel board.
 /// # Example
@@ -161,14 +153,3 @@ impl LED {
     }
 }
 
-/// A model of the single button on Tessel.
-/// # Example
-/// ```
-/// use rust_tessel::Button;
-///
-/// let b = Button{value: false};
-/// ```
-pub struct Button {
-    // The button's current state.
-    pub value: bool,
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,10 @@ mod tests {
     #[test]
     fn led_writes_to_file() {
         let mut tmpfile = tempfile::tempfile().unwrap();
+        // The tmpfile handle can be reused as long as LED gets its own
+        // clone of the handle, and we are diligent about seeking.
+        // This avoids needing to figure out where the tmpfile is in order
+        // to open more handles.
         let mut led = LED::new_with_file(tmpfile.try_clone().unwrap());
         let mut buf = String::new();
         tmpfile.seek(SeekFrom::Start(0)).unwrap();


### PR DESCRIPTION
This PR cleans up the starting code we have in a couple of ways:
1. Fixes formatting to be the same as the official style guide.
2. Adds doctest examples for most stuff.
3. I ran `rustfmt` to keep the code clean.
